### PR TITLE
fix az detection

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -224,6 +224,9 @@ if (!($skipPacksSetup)) {
             $azloggedIn=$true
         }
     }
+    else {
+        $azloggedIn=$false
+    }
 }
 #endregion
 #region AMA policy setup


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

If az isn't available, the flag is never set an breaks setup. (in case deployments aren't done in the CLI).
